### PR TITLE
feat(auth): record last login and add logout endpoint

### DIFF
--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -19,13 +19,14 @@ import { type AuthenticatedUser, type AuthResponse } from './types/auth.types';
 import { REFRESH_TOKEN_TTL_DAYS } from './refresh-token.service';
 
 const REFRESH_COOKIE = 'refresh_token';
+const REFRESH_COOKIE_PATH = '/api/v1/auth';
 
 function refreshCookieOptions(): CookieOptions {
   return {
     httpOnly: true,
     secure: process.env.NODE_ENV !== 'development',
     sameSite: 'strict',
-    path: '/api/v1/auth/refresh',
+    path: REFRESH_COOKIE_PATH,
     maxAge: REFRESH_TOKEN_TTL_DAYS * 24 * 60 * 60 * 1000,
   };
 }
@@ -69,6 +70,19 @@ export class AuthController {
     res.cookie(REFRESH_COOKIE, refreshToken, refreshCookieOptions());
 
     return { accessToken, user };
+  }
+
+  @Post('logout')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  logout(@Req() req: Request, @Res({ passthrough: true }) res: Response): void {
+    const cookies = req.cookies as Record<string, string | undefined>;
+    const token = cookies?.[REFRESH_COOKIE];
+
+    if (token) {
+      this.authService.logout(token);
+    }
+
+    res.clearCookie(REFRESH_COOKIE, refreshCookieOptions());
   }
 
   @UseGuards(JwtAuthGuard)

--- a/backend/src/auth/auth.service.spec.ts
+++ b/backend/src/auth/auth.service.spec.ts
@@ -43,13 +43,17 @@ describe('AuthService', () => {
   ];
 
   let service: AuthService;
+  let recordLogin: jest.Mock;
 
   beforeEach(() => {
+    recordLogin = jest.fn();
+
     const jwtService = {
       signAsync: jest.fn().mockResolvedValue('access-token'),
     } as unknown as JwtService;
 
     const usersService = {
+      recordLogin,
       findByEmailForAuth: (email: string) =>
         Promise.resolve(users.find((user) => user.email === email) ?? null),
       findByIdForAuth: (id: string) =>
@@ -94,6 +98,19 @@ describe('AuthService', () => {
       await expect(service.login(INACTIVE_EMAIL, PASSWORD)).rejects.toThrow(
         UnauthorizedException,
       );
+    });
+    it('records the login timestamp', async () => {
+      await service.login(ACTIVE_EMAIL, PASSWORD);
+
+      expect(recordLogin).toHaveBeenCalledWith('1');
+    });
+
+    it('records nothing when the login fails', async () => {
+      await expect(
+        service.login(ACTIVE_EMAIL, 'wrong-password'),
+      ).rejects.toThrow(UnauthorizedException);
+
+      expect(recordLogin).not.toHaveBeenCalled();
     });
   });
 

--- a/backend/src/auth/auth.service.spec.ts
+++ b/backend/src/auth/auth.service.spec.ts
@@ -99,6 +99,7 @@ describe('AuthService', () => {
         UnauthorizedException,
       );
     });
+
     it('records the login timestamp', async () => {
       await service.login(ACTIVE_EMAIL, PASSWORD);
 

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -80,6 +80,7 @@ export class AuthService {
     if (!user) {
       throw new UnauthorizedException();
     }
+    await this.usersService.recordLogin(user.id);
 
     return this.issueTokens(user);
   }
@@ -96,5 +97,8 @@ export class AuthService {
     }
 
     return this.issueTokens(user);
+  }
+  logout(refreshToken: string): void {
+    this.refreshTokens.revoke(refreshToken);
   }
 }

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -80,6 +80,7 @@ export class AuthService {
     if (!user) {
       throw new UnauthorizedException();
     }
+
     await this.usersService.recordLogin(user.id);
 
     return this.issueTokens(user);
@@ -98,6 +99,7 @@ export class AuthService {
 
     return this.issueTokens(user);
   }
+
   logout(refreshToken: string): void {
     this.refreshTokens.revoke(refreshToken);
   }

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -81,9 +81,10 @@ export class AuthService {
       throw new UnauthorizedException();
     }
 
+    const tokens = await this.issueTokens(user);
     await this.usersService.recordLogin(user.id);
 
-    return this.issueTokens(user);
+    return tokens;
   }
 
   async refresh(refreshToken: string): Promise<LoginResult> {

--- a/backend/src/auth/refresh-token.service.spec.ts
+++ b/backend/src/auth/refresh-token.service.spec.ts
@@ -37,6 +37,14 @@ describe('RefreshTokenService', () => {
     expect(service.consume('not-a-real-token')).toBeNull();
   });
 
+  it('makes a token unusable after logging out', () => {
+    const token = service.issue('user-1');
+
+    service.revoke(token);
+
+    expect(service.consume(token)).toBeNull();
+  });
+
   it('rejects a token used a second time', () => {
     const token = service.issue('user-1');
     service.consume(token);

--- a/backend/src/auth/refresh-token.service.ts
+++ b/backend/src/auth/refresh-token.service.ts
@@ -45,6 +45,10 @@ export class RefreshTokenService {
     return record.userId;
   }
 
+  revoke(token: string): void {
+    this.store.delete(this.hash(token));
+  }
+
   revokeAllForUser(userId: string): void {
     for (const [hash, record] of this.store.entries()) {
       if (record.userId === userId) {

--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -142,6 +142,7 @@ export class UsersService {
 
     return user ? this.excludePasswordHash(user) : null;
   }
+
   async recordLogin(id: string): Promise<void> {
     await this.prisma.user.updateMany({
       where: { id, deletedAt: null },

--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -142,6 +142,12 @@ export class UsersService {
 
     return user ? this.excludePasswordHash(user) : null;
   }
+  async recordLogin(id: string): Promise<void> {
+    await this.prisma.user.updateMany({
+      where: { id, deletedAt: null },
+      data: { lastLogin: new Date() },
+    });
+  }
 
   async updateSelf(
     actorId: string,

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -72,6 +72,7 @@ requests must not trigger two refreshes.
 POST /api/v1/auth/login     { email, password }   →  { accessToken, user }
 POST /api/v1/auth/refresh   (no body)             →  { accessToken, user }
 GET  /api/v1/auth/me        (Bearer token)        →  user
+POST /api/v1/auth/logout    (no body)             →  204, no content
 ```
 
 `user` contains: `id`, `email`, `firstName`, `lastName`, `isDirector`, `accountStatus`, `mustChangePassword`.
@@ -79,7 +80,7 @@ GET  /api/v1/auth/me        (Bearer token)        →  user
 ## Things that will trip you up
 
 - **The refresh token never appears in a response body.** It only ever travels as a cookie. If you're looking for it in JSON, stop.
-- **The refresh cookie is scoped to `/api/v1/auth/refresh`.** The browser will not send it to any other path. That is deliberate.
+- **The refresh cookie is scoped to `/api/v1/auth`.** The browser sends it to the auth endpoints and nowhere else — never to `/api/v1/users/*`. That is deliberate. It has to cover both `/auth/refresh` and `/auth/logout`, otherwise logging out could not revoke the token server-side.
 - **CORS:** the API only accepts requests from the origin set in `CORS_ORIGIN` (`http://localhost:5173` in development). A different port means the request is rejected before it reaches any of this.
 - **`mustChangePassword: true`** means the user is still on an admin-issued password and must set their own before doing anything else.
 - **`isDirector` is not a role.** It is a global admin flag, and it is the only permission this endpoint returns. Project roles (coordinator, executor, partner) are per-project and will arrive on a separate endpoint once projects exist — do not expect them here.

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -80,7 +80,7 @@ POST /api/v1/auth/logout    (no body)             →  204, no content
 ## Things that will trip you up
 
 - **The refresh token never appears in a response body.** It only ever travels as a cookie. If you're looking for it in JSON, stop.
-- **The refresh cookie is scoped to `/api/v1/auth`.** The browser sends it to the auth endpoints and nowhere else — never to `/api/v1/users/*`. That is deliberate. It has to cover both `/auth/refresh` and `/auth/logout`, otherwise logging out could not revoke the token server-side.
+- **The refresh cookie is scoped to `/api/v1/auth`.** The browser sends it to the auth endpoints and nowhere else — never to `/api/v1/users/*`. That is deliberate. It has to cover both `/api/v1/auth/refresh` and `/api/v1/auth/logout`, otherwise logging out could not revoke the token server-side.
 - **CORS:** the API only accepts requests from the origin set in `CORS_ORIGIN` (`http://localhost:5173` in development). A different port means the request is rejected before it reaches any of this.
 - **`mustChangePassword: true`** means the user is still on an admin-issued password and must set their own before doing anything else.
 - **`isDirector` is not a role.** It is a global admin flag, and it is the only permission this endpoint returns. Project roles (coordinator, executor, partner) are per-project and will arrive on a separate endpoint once projects exist — do not expect them here.


### PR DESCRIPTION
## What this adds

- `last_login` is recorded on every successful login. It was always `NULL` before.
- `POST /api/v1/auth/logout` — revokes the refresh token server-side and clears the cookie. Returns 204.

## One behaviour change

The refresh cookie moved from `Path=/api/v1/auth/refresh` to `Path=/api/v1/auth`.

It had to: browsers only send a cookie to paths under its `Path`, so `/auth/logout` never received it. Logout returned 204 and cleared the browser's copy while the token stayed alive on the server for the full 7 days — it looked like it worked, which is the worst kind of broken.

The cookie still never reaches `/api/v1/users/*`. `docs/auth.md` is updated.

Test it with a cookie jar (`curl -c/-b`), not a hand-written `Cookie:` header — a manual header bypasses path matching and hides exactly this bug.

## Known limitations

- **`updatedAt` is now refreshed on every login.** Prisma's `@updatedAt` fires on any update, so that column now means "last login" rather than "profile last modified". Avoiding it needs raw SQL — worth a decision.
- **`revoke()` deletes the record instead of marking it revoked**, so a token replayed after logout reads as unknown rather than as theft and does not trigger family revocation.
- **No e2e tests.** The cookie-path bug was invisible to the unit suite and only showed up against a running server.

Closes #7
