### PR TITLE
feat: add the forgot and reset password screens (F1.11)

### DIFF
--- a/frontend/src/Router.tsx
+++ b/frontend/src/Router.tsx
@@ -19,6 +19,7 @@ import ProjectTasksPage from './pages/ProjectTasksPage';
 import ProjectBudgetPage from './pages/ProjectBudgetPage';
 import ProjectDocumentsPage from './pages/ProjectDocumentsPage';
 import NotFoundPage from './pages/NotFoundPage';
+import ForgotPasswordPage from './features/auth/pages/ForgotPasswordPage';
 
 export default function Router() {
   return (
@@ -27,13 +28,14 @@ export default function Router() {
         <Route element={<AuthLayout />}>
           <Route path="/login" element={<LoginPage />} />
           <Route path="/set-password" element={<SetPasswordPage />} />
+          <Route path="/forgot-password" element={<ForgotPasswordPage />} />
         </Route>
 
         <Route element={<RequireAuth />}>
           <Route element={<MainLayout />}>
             <Route path="/" element={<DashboardPage />} />
             <Route path="/profile" element={<ProfilePage />} />
-        
+
             <Route path="/notifications" element={<NotificationsPage />} />
             <Route element={<RequireModule module="PROJECTS" />}>
               <Route path="/projects" element={<ProjectsPage />} />
@@ -52,7 +54,10 @@ export default function Router() {
               <Route path="/settings" element={<SettingsPage />} />
             </Route>
             <Route element={<RequireModule module="OVERVIEW" />}>
-              <Route path="/project/overview" element={<ProjectOverviewPage />} />
+              <Route
+                path="/project/overview"
+                element={<ProjectOverviewPage />}
+              />
             </Route>
             <Route element={<RequireModule module="TASKS" />}>
               <Route path="/project/tasks" element={<ProjectTasksPage />} />
@@ -61,7 +66,10 @@ export default function Router() {
               <Route path="/project/budget" element={<ProjectBudgetPage />} />
             </Route>
             <Route element={<RequireModule module="DOCUMENTS" />}>
-              <Route path="/project/documents" element={<ProjectDocumentsPage />} />
+              <Route
+                path="/project/documents"
+                element={<ProjectDocumentsPage />}
+              />
             </Route>
           </Route>
         </Route>

--- a/frontend/src/Router.tsx
+++ b/frontend/src/Router.tsx
@@ -20,6 +20,7 @@ import ProjectBudgetPage from './pages/ProjectBudgetPage';
 import ProjectDocumentsPage from './pages/ProjectDocumentsPage';
 import NotFoundPage from './pages/NotFoundPage';
 import ForgotPasswordPage from './features/auth/pages/ForgotPasswordPage';
+import ResetPasswordPage from './features/auth/pages/ResetPasswordPage';
 
 export default function Router() {
   return (
@@ -29,6 +30,7 @@ export default function Router() {
           <Route path="/login" element={<LoginPage />} />
           <Route path="/set-password" element={<SetPasswordPage />} />
           <Route path="/forgot-password" element={<ForgotPasswordPage />} />
+          <Route path="/reset-password" element={<ResetPasswordPage />} />
         </Route>
 
         <Route element={<RequireAuth />}>

--- a/frontend/src/features/auth/hooks/useConfirmPasswordReset.ts
+++ b/frontend/src/features/auth/hooks/useConfirmPasswordReset.ts
@@ -1,0 +1,16 @@
+import { useMutation } from '@tanstack/react-query';
+import { api } from '../../../lib/api';
+
+export function useConfirmPasswordReset() {
+  return useMutation({
+    mutationFn: ({
+      token,
+      newPassword,
+      confirmPassword,
+    }: {
+      token: string;
+      newPassword: string;
+      confirmPassword: string;
+    }) => api.confirmPasswordReset(token, newPassword, confirmPassword),
+  });
+}

--- a/frontend/src/features/auth/hooks/useRequestPasswordReset.ts
+++ b/frontend/src/features/auth/hooks/useRequestPasswordReset.ts
@@ -1,0 +1,8 @@
+import { useMutation } from '@tanstack/react-query';
+import { api } from '../../../lib/api';
+
+export function useRequestPasswordReset() {
+  return useMutation({
+    mutationFn: (email: string) => api.requestPasswordReset(email),
+  });
+}

--- a/frontend/src/features/auth/pages/ForgotPasswordPage.tsx
+++ b/frontend/src/features/auth/pages/ForgotPasswordPage.tsx
@@ -4,6 +4,8 @@ import { Link, useNavigate } from 'react-router';
 import { useRequestPasswordReset } from '../hooks/useRequestPasswordReset';
 import { GoMail } from 'react-icons/go';
 import { Button } from '../../../components/ui/Button';
+import { isApiError } from '../../../lib/api';
+import toast from 'react-hot-toast';
 
 interface FormInputs {
   email: string;
@@ -22,15 +24,29 @@ export default function ForgotPasswordPage() {
   });
 
   const passwordReset = useRequestPasswordReset();
+  const onError = (error: Error) => {
+    const options = { id: 'reset-error' };
 
+    if (!isApiError(error) || error.status !== 429) {
+      toast.error('Coś poszło nie tak. Spróbuj ponownie.', options);
+      return;
+    }
+
+    toast.error(
+      'Zbyt wiele prób. Odczekaj chwilę i spróbuj ponownie.',
+      options,
+    );
+  };
   const onSubmit = (data: FormInputs) => {
     passwordReset.mutate(data.email, {
       onSuccess: () => {
         setEmail(data.email);
         setSent(true);
       },
+      onError,
     });
   };
+
   if (sent) {
     return (
       <>
@@ -67,7 +83,12 @@ export default function ForgotPasswordPage() {
             type="button"
             className="cursor-pointer text-darkGreen transition-all duration-300 hover:text-darkGreenHover hover:underline disabled:opacity-50 disabled:cursor-not-allowed disabled:no-underline"
             disabled={passwordReset.isPending}
-            onClick={() => passwordReset.mutate(email)}
+            onClick={() =>
+              passwordReset.mutate(email, {
+                onSuccess: () => toast.success('Wysłaliśmy nowy link'),
+                onError,
+              })
+            }
           >
             Wyślij link ponownie
           </button>

--- a/frontend/src/features/auth/pages/ForgotPasswordPage.tsx
+++ b/frontend/src/features/auth/pages/ForgotPasswordPage.tsx
@@ -1,0 +1,142 @@
+import { useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { Link, useNavigate } from 'react-router';
+import { useRequestPasswordReset } from '../hooks/useRequestPasswordReset';
+import { GoMail } from 'react-icons/go';
+import { Button } from '../../../components/ui/Button';
+
+interface FormInputs {
+  email: string;
+}
+
+export default function ForgotPasswordPage() {
+  const [sent, setSent] = useState<boolean>(false);
+  const [email, setEmail] = useState<string>('');
+  const navigate = useNavigate();
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<FormInputs>({
+    mode: 'onChange',
+  });
+
+  const passwordReset = useRequestPasswordReset();
+
+  const onSubmit = (data: FormInputs) => {
+    passwordReset.mutate(data.email, {
+      onSuccess: () => {
+        setEmail(data.email);
+        setSent(true);
+      },
+    });
+  };
+  if (sent) {
+    return (
+      <>
+        <h1 className="text-center text-dark font-semibold text-base mb-2 500:text-lg">
+          Sprawdź skrzynkę e-mail
+        </h1>
+
+        <p className="text-center text-xs text-dark/60 mb-4">
+          Jeśli konto o tym adresie istnieje, wysłaliśmy na nie link do
+          ustawienia nowego hasła. Link jest ważny 60 minut.
+        </p>
+
+        <div className="flex justify-center mb-10">
+          <span className="inline-block max-w-full break-all rounded-full bg-[#F4F6F8] px-6 py-1.5 text-xs text-dark/60">
+            {email}
+          </span>
+        </div>
+
+        <div className="flex justify-center">
+          <Button
+            type="button"
+            variant="primary"
+            size="small"
+            className="w-full max-w-[250px] px-3 py-2.5"
+            onClick={() => navigate('/login')}
+          >
+            Wróć do logowania
+          </Button>
+        </div>
+
+        <p className="text-center text-sm text-dark/60 mt-8">
+          Nie dostałeś wiadomości?{' '}
+          <button
+            type="button"
+            className="cursor-pointer text-darkGreen transition-all duration-300 hover:text-darkGreenHover hover:underline disabled:opacity-50 disabled:cursor-not-allowed disabled:no-underline"
+            disabled={passwordReset.isPending}
+            onClick={() => passwordReset.mutate(email)}
+          >
+            Wyślij link ponownie
+          </button>
+        </p>
+      </>
+    );
+  }
+
+  return (
+    <>
+      <h1 className="text-center text-dark font-semibold text-base mb-8 500:text-lg">
+        Nie pamiętasz hasła?
+      </h1>
+
+      <form onSubmit={handleSubmit(onSubmit)} className="space-y-2">
+        <div>
+          <label className="block text-dark font-semibold text-xs mb-2">
+            E-mail
+          </label>
+          <div className="group relative">
+            <GoMail className="absolute left-3 top-1/2 -translate-y-1/2 text-dark opacity-40 group-focus-within:text-darkGreen group-focus-within:opacity-100 transition-all w-4 h-4" />
+            <input
+              type="email"
+              placeholder="Podaj e-mail..."
+              className="text-xs w-full h-10 pl-10 pr-4 bg-white border border-gray-100 transition-all hover:border-darkGreen/60 rounded-lg text-dark placeholder-dark placeholder-opacity-30 focus:outline-none focus:ring-1 focus:ring-darkGreen/60 focus:border-transparent"
+              {...register('email', {
+                required: 'E-mail jest wymagany',
+                pattern: {
+                  value: /^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}$/i,
+                  message: 'Podaj poprawny adres e-mail',
+                },
+              })}
+            />
+          </div>
+          <div className="min-h-4 mt-0.5">
+            <p
+              className={`text-red-500 text-xs transition duration-200 ease-out ${
+                errors.email
+                  ? 'opacity-100 translate-y-0'
+                  : 'opacity-0 -translate-y-0.5'
+              }`}
+            >
+              {errors.email?.message}
+            </p>
+          </div>
+        </div>
+
+        <div className="flex justify-center">
+          <Button
+            type="submit"
+            variant="primary"
+            size="small"
+            className="px-3 py-2.5"
+            isPending={passwordReset.isPending}
+          >
+            Wyślij link do hasła
+          </Button>
+        </div>
+      </form>
+
+      <p className="text-center text-xs text-dark mt-8">
+        Pamiętasz hasło?{' '}
+        <Link
+          to="/login"
+          className="font-semibold text-darkGreen transition-all duration-300 hover:text-darkGreenHover hover:underline"
+        >
+          Wróć do logowania
+        </Link>
+      </p>
+    </>
+  );
+}

--- a/frontend/src/features/auth/pages/LoginPage.tsx
+++ b/frontend/src/features/auth/pages/LoginPage.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { useForm } from 'react-hook-form';
-import { useNavigate } from 'react-router';
+import { Link, useNavigate } from 'react-router';
 import toast from 'react-hot-toast';
 import { GoMail } from 'react-icons/go';
 import { Button } from '../../../components/ui/Button';
@@ -96,7 +96,9 @@ export default function LoginPage() {
           <div className="min-h-4 mt-0.5">
             <p
               className={`text-red-500 text-xs transition duration-200 ease-out ${
-                errors.email ? 'opacity-100 translate-y-0' : 'opacity-0 -translate-y-0.5'
+                errors.email
+                  ? 'opacity-100 translate-y-0'
+                  : 'opacity-0 -translate-y-0.5'
               }`}
             >
               {errors.email?.message}
@@ -113,7 +115,9 @@ export default function LoginPage() {
           <div className="min-h-4 mt-0.5">
             <p
               className={`text-red-500 text-xs transition duration-200 ease-out ${
-                errors.password ? 'opacity-100 translate-y-0' : 'opacity-0 -translate-y-0.5'
+                errors.password
+                  ? 'opacity-100 translate-y-0'
+                  : 'opacity-0 -translate-y-0.5'
               }`}
             >
               {errors.password?.message}
@@ -122,12 +126,12 @@ export default function LoginPage() {
         </div>
 
         <div className="text-right">
-          <a
-            href="#"
+          <Link
+            to="/forgot-password"
             className="text-darkGreen text-xs font-medium transition-all duration-300 hover:text-darkGreenHover hover:underline"
           >
             Nie pamiętasz hasła?
-          </a>
+          </Link>
         </div>
 
         <div className="flex justify-center">

--- a/frontend/src/features/auth/pages/ResetPasswordPage.tsx
+++ b/frontend/src/features/auth/pages/ResetPasswordPage.tsx
@@ -1,0 +1,233 @@
+import { useForm, useWatch } from 'react-hook-form';
+import { Link, useNavigate, useSearchParams } from 'react-router';
+import toast from 'react-hot-toast';
+import { IoCheckmarkCircle } from 'react-icons/io5';
+import { GoAlert, GoCircle } from 'react-icons/go';
+import { Button } from '../../../components/ui/Button';
+import { PasswordInput } from '../../../components/ui/PasswordInput';
+import { isApiError } from '../../../lib/api';
+import { useConfirmPasswordReset } from '../hooks/useConfirmPasswordReset';
+import { useState } from 'react';
+
+interface PasswordRule {
+  label: string;
+  test: (value: string) => boolean;
+}
+
+const passwordRules: PasswordRule[] = [
+  { label: 'Co najmniej 8 znaków', test: (v) => v.length >= 8 },
+  {
+    label: 'Wielka i mała litera',
+    test: (v) => /[a-z]/.test(v) && /[A-Z]/.test(v),
+  },
+  { label: 'Co najmniej jedna cyfra', test: (v) => /\d/.test(v) },
+  { label: 'Znak specjalny: @ $ ! % * ? &', test: (v) => /[@$!%*?&]/.test(v) },
+];
+
+interface ResetPasswordFormInputs {
+  newPassword: string;
+  confirmPassword: string;
+}
+
+export default function ResetPasswordPage() {
+  const navigate = useNavigate();
+  const {
+    register,
+    handleSubmit,
+    control,
+    formState: { errors },
+  } = useForm<ResetPasswordFormInputs>({
+    mode: 'onChange',
+  });
+  const [searchParams] = useSearchParams();
+  const newPasswordMutation = useConfirmPasswordReset();
+  const newPasswordValue = useWatch({ control, name: 'newPassword' }) ?? '';
+  const [linkDead, setLinkDead] = useState<boolean>(false);
+
+  const token = searchParams.get('token');
+
+  if (!token || linkDead) {
+    return (
+      <>
+        <h1 className="text-center text-dark font-semibold text-base mb-2 500:text-lg">
+          Link jest nieaktualny
+        </h1>
+
+        <p className="text-center text-xs text-dark/60 mb-6">
+          Ten link do ustawienia hasła wygasł lub został już użyty. Wyślij nowy
+          link, żeby ustawić hasło.
+        </p>
+
+        <div className="flex items-start gap-3 rounded-lg bg-[#FDF4EC] px-4 py-3 mb-10">
+          <GoAlert className="mt-0.5 w-3.5 h-3.5 shrink-0 text-[#C2703A]" />
+          <div className="text-xs text-dark/60 space-y-1">
+            <p>Link jest ważny 60 minut i można użyć go tylko raz.</p>
+            <p>Otwórz zawsze najnowszą wiadomość e-mail.</p>
+          </div>
+        </div>
+
+        <div className="flex justify-center">
+          <Button
+            type="button"
+            variant="primary"
+            size="small"
+            className="w-full max-w-[250px] px-3 py-2.5"
+            onClick={() => navigate('/forgot-password')}
+          >
+            Wyślij nowy link
+          </Button>
+        </div>
+
+        <p className="text-center text-sm text-dark/60 mt-8">
+          Pamiętasz hasło?{' '}
+          <Link
+            to="/login"
+            className="text-darkGreen transition-all duration-300 hover:text-darkGreenHover hover:underline"
+          >
+            Wróć do logowania
+          </Link>
+        </p>
+      </>
+    );
+  }
+  const onSubmit = (data: ResetPasswordFormInputs) =>
+    newPasswordMutation.mutate(
+      {
+        token: token,
+        newPassword: data.newPassword,
+        confirmPassword: data.confirmPassword,
+      },
+      {
+        onSuccess: () => {
+          toast.success('Hasło zostało ustawione');
+          navigate('/login');
+        },
+        onError: (error) => {
+          if (isApiError(error) && error.status === 400) {
+            setLinkDead(true);
+          } else {
+            toast.error('Coś poszło nie tak. Spróbuj ponownie.');
+          }
+        },
+      },
+    );
+
+  return (
+    <>
+      <h1 className="text-center text-dark font-semibold text-base mb-3  500:text-lg">
+        Ustaw nowe hasło
+      </h1>
+
+      <p className="text-center text-xs text-dark opacity-70 mb-2">
+        Wpisz nowe hasło do swojego konta w Wirtualnym Biurze. Link z wiadomości
+        działa tylko raz.
+      </p>
+
+      <form onSubmit={handleSubmit(onSubmit)} className="space-y-3">
+        <div>
+          <PasswordInput
+            label="Nowe hasło"
+            placeholder="Wpisz nowe hasło..."
+            {...register('newPassword', {
+              required: 'Hasło jest wymagane',
+              minLength: { value: 8, message: 'Hasło musi mieć min. 8 znaków' },
+              validate: (value) => {
+                return (
+                  passwordRules.every((rule) => rule.test(value)) ||
+                  'Hasło nie spełnia wymagań'
+                );
+              },
+            })}
+          />
+          <div className="min-h-4 mt-0.5">
+            <p
+              className={`text-red-500 text-xs transition duration-200 ease-out ${
+                errors.newPassword
+                  ? 'opacity-100 translate-y-0'
+                  : 'opacity-0 -translate-y-0.5'
+              }`}
+            >
+              {errors.newPassword?.message}
+            </p>
+          </div>
+
+          <div className="mt-1.5 space-y-1">
+            {passwordRules.map((rule) => {
+              const met = rule.test(newPasswordValue);
+              return (
+                <div key={rule.label} className="flex items-center gap-2">
+                  <span className="relative inline-flex w-4 h-4 shrink-0">
+                    <GoCircle
+                      className={`absolute inset-0 w-4 h-4 text-gray-300 transition-opacity duration-200 ease-out ${
+                        met ? 'opacity-0' : 'opacity-100'
+                      }`}
+                    />
+                    <IoCheckmarkCircle
+                      className={`absolute inset-0 w-4 h-4 text-darkGreen transition-opacity duration-200 ease-out ${
+                        met ? 'opacity-100' : 'opacity-0'
+                      }`}
+                    />
+                  </span>
+                  <span
+                    className={`text-xs transition-colors duration-200 ease-out ${
+                      met ? 'text-darkGreen' : 'text-gray-400'
+                    }`}
+                  >
+                    {rule.label}
+                  </span>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+
+        <div>
+          <PasswordInput
+            label="Powtórz nowe hasło"
+            placeholder="Wpisz hasło ponownie"
+            {...register('confirmPassword', {
+              required: 'Powtórz hasło',
+              validate: (value, formValues) =>
+                value === formValues.newPassword || 'Hasła nie są takie same',
+            })}
+          />
+          <div className="min-h-4 mt-0.5">
+            <p
+              className={`text-red-500 text-xs transition duration-200 ease-out ${
+                errors.confirmPassword
+                  ? 'opacity-100 translate-y-0'
+                  : 'opacity-0 -translate-y-0.5'
+              }`}
+            >
+              {errors.confirmPassword?.message}
+            </p>
+          </div>
+        </div>
+
+        <div className="flex justify-center">
+          <Button
+            type="submit"
+            variant="primary"
+            size="small"
+            className="px-3 py-2.5"
+            isPending={newPasswordMutation.isPending}
+          >
+            {newPasswordMutation.isPending
+              ? 'Ustawianie hasła...'
+              : 'Zapisz nowe hasło'}
+          </Button>
+        </div>
+      </form>
+
+      <p className="text-center text-xs text-dark mt-3 mb-1">
+        Pamiętasz hasło?{' '}
+        <Link
+          to="/login"
+          className="font-semibold text-darkGreen transition-all duration-300 hover:text-darkGreenHover hover:underline"
+        >
+          Wróć do logowania
+        </Link>
+      </p>
+    </>
+  );
+}

--- a/frontend/src/features/auth/pages/ResetPasswordPage.tsx
+++ b/frontend/src/features/auth/pages/ResetPasswordPage.tsx
@@ -1,4 +1,5 @@
 import { useForm, useWatch } from 'react-hook-form';
+import { useQueryClient } from '@tanstack/react-query';
 import { Link, useNavigate, useSearchParams } from 'react-router';
 import toast from 'react-hot-toast';
 import { IoCheckmarkCircle } from 'react-icons/io5';
@@ -7,6 +8,7 @@ import { Button } from '../../../components/ui/Button';
 import { PasswordInput } from '../../../components/ui/PasswordInput';
 import { isApiError } from '../../../lib/api';
 import { useConfirmPasswordReset } from '../hooks/useConfirmPasswordReset';
+import { useAuth } from '../../../context/useAuth';
 import { useState } from 'react';
 
 interface PasswordRule {
@@ -31,6 +33,8 @@ interface ResetPasswordFormInputs {
 
 export default function ResetPasswordPage() {
   const navigate = useNavigate();
+  const { clearSession } = useAuth();
+  const queryClient = useQueryClient();
   const {
     register,
     handleSubmit,
@@ -100,6 +104,10 @@ export default function ResetPasswordPage() {
       {
         onSuccess: () => {
           toast.success('Hasło zostało ustawione');
+          // The backend just revoked every session for this user; drop ours too,
+          // so a logged-in visitor cannot keep browsing on the old one.
+          clearSession();
+          queryClient.clear();
           navigate('/login');
         },
         onError: (error) => {
@@ -137,6 +145,7 @@ export default function ResetPasswordPage() {
                   'Hasło nie spełnia wymagań'
                 );
               },
+              deps: ['confirmPassword'],
             })}
           />
           <div className="min-h-4 mt-0.5">

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -289,6 +289,26 @@ export const api = {
       );
     }
   },
+
+  async requestPasswordReset(email: string): Promise<{ message: string }> {
+    return request<{ message: string }>('/api/v1/auth/password-reset/request', {
+      method: 'POST',
+      body: { email },
+      fallbackMessage: 'Nie udało się wysłać linku',
+    });
+  },
+
+  async confirmPasswordReset(
+    token: string,
+    newPassword: string,
+    confirmPassword: string,
+  ): Promise<{ message: string }> {
+    return request<{ message: string }>('/api/v1/auth/password-reset/confirm', {
+      method: 'POST',
+      body: { token, newPassword, confirmPassword },
+      fallbackMessage: 'Nie udało się zmienić hasła',
+    });
+  },
 };
 
 export { isApiError };


### PR DESCRIPTION
Adds /forgot-password and /reset-password.

The request screen shows the same confirmation whether or not the address has
an account, matching the backend. The reset screen reads the token from the
query string; a rejected or missing token swaps the page for a "link is no
longer valid" message. A successful reset clears the local session, since the
backend revokes every session for that user.

Note: SetPasswordPage shows the same rule checklist but only validates minimum
length, so a weak password is submitted and rejected by the API. Needs its own
ticket.

Closes #17